### PR TITLE
Enable 16x MSAA in render pass

### DIFF
--- a/include/App.hpp
+++ b/include/App.hpp
@@ -20,45 +20,50 @@ namespace ff {
         App(const Window &window);
         ~App();
 
+        static constexpr vk::SampleCountFlagBits SAMPLE_COUNT = vk::SampleCountFlagBits::e16;
+
         void drawFrame();
 
     private:
 
-        // Создание инстанса
+        // РЎРѕР·РґР°РЅРёРµ РёРЅСЃС‚Р°РЅСЃР°
         void createInstance();
         const std::vector<const char*> getExtensions() const;
 
-        // Создание логического устройства
+        // РЎРѕР·РґР°РЅРёРµ Р»РѕРіРёС‡РµСЃРєРѕРіРѕ СѓСЃС‚СЂРѕР№СЃС‚РІР°
         void createDevice();
 
-        // Создание очередей
+        // РЎРѕР·РґР°РЅРёРµ РѕС‡РµСЂРµРґРµР№
         void createQueues();
 
-        // Создание поверхности
+        // РЎРѕР·РґР°РЅРёРµ РїРѕРІРµСЂС…РЅРѕСЃС‚Рё
         void createSurface(const Window &window);
 
-        // Создание представлений изображений и удаление
+        // РЎРѕР·РґР°РЅРёРµ РїСЂРµРґСЃС‚Р°РІР»РµРЅРёР№ РёР·РѕР±СЂР°Р¶РµРЅРёР№ Рё СѓРґР°Р»РµРЅРёРµ
         void createImageViews();
         void destroyImageViews() const;
         vk::Format findSupportedDepthFormat();
 
-        // Создание прохода рендера
+        // РЎРѕР·РґР°РЅРёРµ РїСЂРѕС…РѕРґР° СЂРµРЅРґРµСЂР°
         void createRenderPass();
 
-        // Создание фреймбуфферов
+        void createColorResources();
+        void destroyColorResources() const;
+
+        // РЎРѕР·РґР°РЅРёРµ С„СЂРµР№РјР±СѓС„С„РµСЂРѕРІ
         void createFrameBuffers();
         void destroyFramebuffers() const;
 
-        // Создание пула команд
+        // РЎРѕР·РґР°РЅРёРµ РїСѓР»Р° РєРѕРјР°РЅРґ
         void createCommandPool();
 
-        // Создание буфера команд
+        // РЎРѕР·РґР°РЅРёРµ Р±СѓС„РµСЂР° РєРѕРјР°РЅРґ
         void allocateCommandBuffers();
 
-        // Запись данных в буфер команд
+        // Р—Р°РїРёСЃСЊ РґР°РЅРЅС‹С… РІ Р±СѓС„РµСЂ РєРѕРјР°РЅРґ
         void writeDataIntoCommandBuffers(uint32_t imageIndex);
 
-        // Семафоры и fence
+        // РЎРµРјР°С„РѕСЂС‹ Рё fence
         void createSyncObjects();
 
         vk::Instance instance{};
@@ -69,17 +74,20 @@ namespace ff {
         std::vector<vk::ImageView> imageViews{};
         ff::Pipeline pipeline{};
         vk::RenderPass renderPass{};
+        std::vector<vk::Image> colorImages{};
+        std::vector<vk::DeviceMemory> colorImageMemories{};
+        std::vector<vk::ImageView> colorImageViews{};
         std::vector<vk::Framebuffer> framebuffers{};
         vk::CommandPool commandPool{};
         std::vector<vk::CommandBuffer> commandBuffers{};
 
         // ---
-        // Очереди
+        // РћС‡РµСЂРµРґРё
         vk::Queue graphicsQueue{};
         vk::Queue presentQueue{};
         // ---
 
-        // Объекты синхронизации
+        // РћР±СЉРµРєС‚С‹ СЃРёРЅС…СЂРѕРЅРёР·Р°С†РёРё
         vk::Semaphore imageAvailableSemaphore{};
         vk::Semaphore renderFinishedSemaphore{};
         vk::Fence inFlightFense{};

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -1,4 +1,5 @@
 #include "Pipeline.hpp"
+#include "App.hpp"
 
 ff::Pipeline::Pipeline() {
 }
@@ -13,7 +14,7 @@ void ff::Pipeline::init(
         const std::string &vertexShaderPath,
         const std::string &fragmentShaderPath,
         const ff::PhysicalDevice &physicalDevice) {
-    // 1) Загрузка шейдеров
+    // 1) Р—Р°РіСЂСѓР·РєР° С€РµР№РґРµСЂРѕРІ
     auto vertCode = ff::utils::readFile(vertexShaderPath);
     auto fragCode = ff::utils::readFile(fragmentShaderPath);
     vertexShaderModule   = createShaderModule(device, vertCode);
@@ -29,12 +30,12 @@ void ff::Pipeline::init(
              .setPName("main");
     std::array<vk::PipelineShaderStageCreateInfo, 2> shaderStages = {{ vertStage, fragStage }};
 
-    // 2) Создание UBO-буфера под std140 binding=0
+    // 2) РЎРѕР·РґР°РЅРёРµ UBO-Р±СѓС„РµСЂР° РїРѕРґ std140 binding=0
     struct alignas(16) UBO {
         float uResolution[2];
-        float _padding1[2];  // выравнивание vec2 до 16 байт
+        float _padding1[2];  // РІС‹СЂР°РІРЅРёРІР°РЅРёРµ vec2 РґРѕ 16 Р±Р°Р№С‚
         float uTime;
-        float _padding2[3];  // выравнивание всей структуры до 16 байт
+        float _padding2[3];  // РІС‹СЂР°РІРЅРёРІР°РЅРёРµ РІСЃРµР№ СЃС‚СЂСѓРєС‚СѓСЂС‹ РґРѕ 16 Р±Р°Р№С‚
     };
 
     vk::BufferCreateInfo bufInfo{};
@@ -124,7 +125,8 @@ void ff::Pipeline::init(
     rasterization.setLineWidth(1.0f);
 
     vk::PipelineMultisampleStateCreateInfo multisampling{};
-    multisampling.setMinSampleShading(1.0f);
+    multisampling.setRasterizationSamples(ff::App::SAMPLE_COUNT);
+    multisampling.setSampleShadingEnable(VK_FALSE);
 
     vk::PipelineColorBlendAttachmentState colorBlendAttachment{};
     colorBlendAttachment.setColorWriteMask(
@@ -176,7 +178,7 @@ void ff::Pipeline::destroy(const vk::Device &device) const {
 
 vk::Pipeline ff::Pipeline::get() const { return pipeline; }
 
-// Обновление UBO перед отрисовкой void 
+// РћР±РЅРѕРІР»РµРЅРёРµ UBO РїРµСЂРµРґ РѕС‚СЂРёСЃРѕРІРєРѕР№ void 
 void ff::Pipeline::updateUniform(
           const vk::Device &device,
           const vk::Extent2D &resolution,


### PR DESCRIPTION
## Summary
- add constant sample count in `App`
- allocate and destroy multisampled color resources
- update render pass and framebuffers for MSAA resolve
- configure pipeline multisampling

## Testing
- `cmake .. && make -j4` *(fails: CMake 3.30 required)*

------
https://chatgpt.com/codex/tasks/task_e_68401e6ca4d8832e985356bfdd8009cb